### PR TITLE
Added the ability to set default values (Issue #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,42 @@ waitUntil()
     });
 ```
 
+### Defining defaults
+
+By default the values for `.interval()` and `.times()` are both set to `100`. This allows you to go straight to using `.condition()` and `.done()` without ever having to define `.interval()` and `.times()`.
+
+If you aren't happy with the default settings, you can can change them by doing this:
+
+```js
+var waitUntil = require('wait-until');
+
+// Define new global default settings
+waitUntil()
+    .defaults({
+        interval: 500,
+        times: 10
+    });
+
+// Use waitUntil() using the default settings defined above
+waitUntil()
+    .condition(function() {
+        return (someCondition ? true : false);
+    })
+    .done(function(result) {
+        // do stuff
+    });
+
+//Using .interval() and .times() will override the default values
+waitUntil()
+    .interval(200)
+    .condition(function() {
+        return (someCondition ? true : false);
+    })
+    .done(function(result) {
+        // do stuff
+    });
+```
+
 ### Async conditions
 
 If the `condition` function accepts an argument, then it is assumed to be a

--- a/index.js
+++ b/index.js
@@ -10,6 +10,12 @@ module.exports = exports = function waitUntil(interval, times, condition, cb) {
     }
 };
 
+//100 millisecond intervals over 10 seconds
+var defaults = {
+    interval: 100,
+    times: 100,
+}
+
 function WaitUntil() {
     var self = this;
 }
@@ -28,6 +34,16 @@ WaitUntil.prototype.times = function(_times) {
     return self;
 };
 
+WaitUntil.prototype.defaults = function(_newDefaults) {
+    var self = this;
+
+    for (var property in _newDefaults) {
+        defaults[property] = _newDefaults[property];
+    }
+
+    return self;
+};
+
 WaitUntil.prototype.condition = function(_condition, cb) {
     var self = this;
 
@@ -43,10 +59,10 @@ WaitUntil.prototype.done = function(cb) {
     var self = this;
 
     if (!self._times) {
-        throw new Error('waitUntil.times() not called yet');
+        self._times = defaults.times;
     }
     if (!self._interval) {
-        throw new Error('waitUntil.interval() not called yet');
+        self._interval = defaults.interval;
     }
     if (!self._condition) {
         throw new Error('waitUntil.condition() not called yet');


### PR DESCRIPTION
This pull request gives people access to these new features:

````js
//Define global default values
waitUntil()
    .defaults({
        times: 100,
        interval: 500
    });

var test = false;
setTimeout(()=> test = true, 3000);

//Use waitUntil without having to define .times() and .interval() every time
waitUntil()
   .condition(()=>test)
   .done(()=>{
       console.log('success!');
   });

//Using .interval() and .times() overrides the default values
//but it will still use the defaults if they have not been overridden
waitUntil()
   .interval(200)
   .condition(()=>test)
   .done(()=>{
       console.log('success!');
   });
````

It also provides a standard set of default values for `.times()` and `.interval()` so that people can use the function without ever having to use `.defaults()`, `.times()`, or `.interval()`

I have set the default values to test every 100 milliseconds, 100 times.

This does not introduce any breaking changes.