### PR TITLE
Replace nextTick with setImmediate to use with React Native.

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,9 +69,15 @@ WaitUntil.prototype.done = function(cb) {
                     self._condition(gotConditionResult);
                 } else {
                     // don't release Zalgo
-                    process.nextTick(function() {
+                    if (process.nextTick) {
+                      process.nextTick(function() {
                         gotConditionResult(self._condition());
-                    });
+                      });
+                    } else {
+                      setImmediate(function() {
+                        gotConditionResult(self._condition());
+                      });
+                    }
                 }
             }, self._interval);
         }


### PR DESCRIPTION
`process.nextTick` doesn't exist on React Native. Apparently `setImmediate' is a reasonable polyfill. Note that this is untested on `node` or in the browser, but I can confirm that it works on React Native.